### PR TITLE
Package license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include COPYING.md

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,9 @@ setup(
     packages=find_packages(),
     license='3-BSD',
     long_description=open('README.rst').read(),
+    author="Jupyter Development Team",
+    author_email="jupyter@googlegroups.com",
+    url="https://jupyter.org",
     entry_points={
         'console_scripts': [
             'cull_idle_servers.py = jupyterhub_idle_culler:main',
@@ -15,6 +18,5 @@ setup(
     install_requires=[
         'tornado',
         'python-dateutil'
-    ],
-#    include_package_data=True
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,6 @@ setup(
     install_requires=[
         'tornado',
         'python-dateutil'
-    ]
+    ],
+    include_package_data=True
 )

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,5 @@ setup(
         'tornado',
         'python-dateutil'
     ],
-    include_package_data=True
+#    include_package_data=True
 )


### PR DESCRIPTION
Hi @yuvipanda. I'm adding jupyterhub-idle-culler to conda-forge. I see that the license isn't packaged with the source. According to the BSD-3-clause license we gotta include the license with the source. This PR adds the bits to this repo to include the license in the tarball the next time you release. I can bundle the license in the conda-forge package until you need to make a new release (in other words, please don't feel like I'm pressuring you to make another release just for this license!).

Without the MANIFEST.in:
```
$ python setup.py sdist
running sdist                                                                                                                                
running egg_info                                                                                                                             
creating jupyterhub_idle_culler.egg-info                              
writing jupyterhub_idle_culler.egg-info/PKG-INFO                      
writing dependency_links to jupyterhub_idle_culler.egg-info/dependency_links.txt
writing entry points to jupyterhub_idle_culler.egg-info/entry_points.txt                                                                    
writing requirements to jupyterhub_idle_culler.egg-info/requires.txt                                                                         
writing top-level names to jupyterhub_idle_culler.egg-info/top_level.txt                                                                 
writing manifest file 'jupyterhub_idle_culler.egg-info/SOURCES.txt'   
reading manifest file 'jupyterhub_idle_culler.egg-info/SOURCES.txt'                                                                          
writing manifest file 'jupyterhub_idle_culler.egg-info/SOURCES.txt'                                                                          
running check                                                                                                                                
warning: check: missing required meta-data: url                       
                                                                      
warning: check: missing meta-data: either (author and author_email) or (maintainer and maintainer_email) must be supplied
                                                                                                                                             
creating jupyterhub-idle-culler-1.0                                                                                                          
creating jupyterhub-idle-culler-1.0/jupyterhub_idle_culler                                                                                   
creating jupyterhub-idle-culler-1.0/jupyterhub_idle_culler.egg-info                                                                          
copying files to jupyterhub-idle-culler-1.0...                                                                                               
copying README.rst -> jupyterhub-idle-culler-1.0                                                                                             
copying setup.py -> jupyterhub-idle-culler-1.0                                                                                               
copying jupyterhub_idle_culler/__init__.py -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler                  
copying jupyterhub_idle_culler/__main__.py -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler                                              
copying jupyterhub_idle_culler.egg-info/PKG-INFO -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler.egg-info                               
copying jupyterhub_idle_culler.egg-info/SOURCES.txt -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler.egg-info                            
copying jupyterhub_idle_culler.egg-info/dependency_links.txt -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler.egg-info                  
copying jupyterhub_idle_culler.egg-info/entry_points.txt -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler.egg-info                       
copying jupyterhub_idle_culler.egg-info/requires.txt -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler.egg-info                           
copying jupyterhub_idle_culler.egg-info/top_level.txt -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler.egg-info   
Writing jupyterhub-idle-culler-1.0/setup.cfg                                                                                                 
creating dist                                                                                                                                
Creating tar archive
removing 'jupyterhub-idle-culler-1.0' (and everything under it)
```
(no COPYING.md)

With the MANIFEST.in:
```
running sdist
running egg_info
creating jupyterhub_idle_culler.egg-info
writing jupyterhub_idle_culler.egg-info/PKG-INFO
writing dependency_links to jupyterhub_idle_culler.egg-info/dependency_links.txt
writing entry points to jupyterhub_idle_culler.egg-info/entry_points.txt
writing requirements to jupyterhub_idle_culler.egg-info/requires.txt
writing top-level names to jupyterhub_idle_culler.egg-info/top_level.txt
writing manifest file 'jupyterhub_idle_culler.egg-info/SOURCES.txt'
reading manifest file 'jupyterhub_idle_culler.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'jupyterhub_idle_culler.egg-info/SOURCES.txt'
running check
creating jupyterhub-idle-culler-1.0
creating jupyterhub-idle-culler-1.0/jupyterhub_idle_culler
creating jupyterhub-idle-culler-1.0/jupyterhub_idle_culler.egg-info
copying files to jupyterhub-idle-culler-1.0...
copying COPYING.md -> jupyterhub-idle-culler-1.0
copying MANIFEST.in -> jupyterhub-idle-culler-1.0
copying README.rst -> jupyterhub-idle-culler-1.0
copying setup.py -> jupyterhub-idle-culler-1.0
copying jupyterhub_idle_culler/__init__.py -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler
copying jupyterhub_idle_culler/__main__.py -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler
copying jupyterhub_idle_culler.egg-info/PKG-INFO -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler.egg-info
copying jupyterhub_idle_culler.egg-info/SOURCES.txt -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler.egg-info
copying jupyterhub_idle_culler.egg-info/dependency_links.txt -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler.egg-info
copying jupyterhub_idle_culler.egg-info/entry_points.txt -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler.egg-info
copying jupyterhub_idle_culler.egg-info/requires.txt -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler.egg-info
copying jupyterhub_idle_culler.egg-info/top_level.txt -> jupyterhub-idle-culler-1.0/jupyterhub_idle_culler.egg-info
Writing jupyterhub-idle-culler-1.0/setup.cfg
creating dist
Creating tar archive
removing 'jupyterhub-idle-culler-1.0' (and everything under it)

```

I also noticed some warnings in the python setup.py sdist output, so I added the url and author info. Happy to pull that back out if you'd rather not include it.