### PR TITLE
Change default request_timeout and allow override

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,6 @@ The command line interface also gives a quick overview of the different options 
    users and users' servers. If you want a different value for users and servers,
    you should add this script to the services list twice, just with different
    `name`s, different values, and one with the `--cull-users` option.
+
+3. By default HTTP requests to the hub timeout after 60 seconds. This can be
+   changed by setting the `JUPYTERHUB_REQUEST_TIMEOUT` environment variable.


### PR DESCRIPTION
In a hub that's older than 1.3.0 where we don't do server
side filtering, if there are a lot of users the `GET /users`
request can timeout the default tornado 20 second request
timeout.

This changes the default request timeout to 60 seconds but
provides an environment variable to override that value.

Closes #26