### PR TITLE
Add documentation about how it works in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,14 +122,16 @@ that combines two sources of information.
 
    The `update_last_activity` function will [ask the
    proxy](https://jupyterhub.readthedocs.io/en/stable/reference/proxy.html#retrieving-routes)
-   for the active routes and collects associated `last_activity` data if it is
-   available.
+   for the active routes like `/user/user1` and collects associated
+   `last_activity` data if it is available. This activity represents
+   successfully proxies network traffic.
 
    `last_activity` data for routes will be available when using
    [configurable-http-proxy](https://github.com/jupyterhub/configurable-http-proxy#readme)
    as JupyterHub does by default, but if for example
-   [traefik-proxy](https://github.com/jupyterhub/traefik-proxy#readme) is used,
-   no such data will be available.
+   [traefik-proxy](https://github.com/jupyterhub/traefik-proxy#readme) is used
+   as it is in the [TLJH distribution](https://tljh.jupyter.org), no such data
+   will be available.
 
 2. **The user server's activity reports**
 
@@ -138,8 +140,7 @@ that combines two sources of information.
    whenever a server notifies JupyterHub about activity, as they are
    responsibility to do.
 
-   As the servers need to be aware of JupyterHub to notify it about activity,
-   they are supposed to be started via the
+   Servers notify JupyterHub about activity by being started by the
    [`jupyterhub-singleuser`](https://github.com/jupyterhub/jupyterhub/blob/1.4.2/setup.py#L115)
    script that is made available by installing jupyterhub (or `jupyterhub-base`
    on conda-forge).
@@ -155,7 +156,8 @@ that combines two sources of information.
    and
    [ServerApp](https://github.com/jupyter-server/jupyter_server/blob/v1.9.0/jupyter_server/serverapp.py#L375)
    respectively) that that combines information from API activity, kernel
-   activity, kernel shutdown, and terminal activity.
+   activity, kernel shutdown, and terminal activity. This activity also covers
+   activity of applications like RStudio running via `jupyter-server-proxy`.
 
 Here is a summary of what's described so far:
 


### PR DESCRIPTION
@cdibble started documenting details on how jupyterhub-idle-culler works in https://github.com/jupyterhub/zero-to-jupyterhub-k8s/pull/2267, but I think such documentation should go here and be linked to from a distribution of jupyterhub like z2jh or tljh.

This PR is meant to help users understand `jupyterhub-idle-culler` a bit better so that they can better figure out how to configure it and better understand what to expect it can accomplish and how a kernel culler can work together with it.

A rendered preview of the README can be found [here](https://github.com/jupyterhub/jupyterhub-idle-culler/blob/1f31a566c42436cd122a4efeeb7afae8cb25284d/README.md). I consider this ready for final review and merge at this point.