### PR TITLE
support JupyterHub 2.0 API pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ python3 -m jupyterhub-idle-culler [--timeout=900] [--url=http://localhost:8081/h
 The command line interface also gives a quick overview of the different options for configuration.
 
 ```
+  --api-page-size                  Number of users to request per page, when
+                                   using JupyterHub 2.0's paginated user list
+                                   API. Default: user the server-side default
+                                   configured page size. (default 0)
   --concurrency                    Limit the number of concurrent requests made
                                    to the Hub.  Deleting a lot of users at the
                                    same time can slow down the Hub, so limit

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,6 @@ setup(
             "jupyterhub-idle-culler = jupyterhub_idle_culler:main",
         ]
     },
+    python_requires=">=3.6",
     install_requires=["tornado", "python-dateutil"],
 )


### PR DESCRIPTION
Pagination is coming in JupyterHub 2.0, implemented behind an Accept header in https://github.com/jupyterhub/jupyterhub/pull/3535

- adds `fetch_paginated` async generator to yield items from a paginated endpoint

- adopt async/await syntax, requiring Python 3.6 for async generator syntax (Python 3.6 was already the baseline in CI, but not specified in package metadata)

- cull inactive users *before* culling ready servers. This should avoid an unlikely async race where both paths may try to delete the same user, but that I triggered running with very small thresholds to test
