### PR TITLE
Avoid the need for read:hub scope

### DIFF
--- a/jupyterhub_idle_culler/__init__.py
+++ b/jupyterhub_idle_culler/__init__.py
@@ -161,10 +161,10 @@ async def cull_idle(
     # using the `state` filter parameter. "ready" means all users who have any
     # ready servers (running, not pending).
     auth_header = {"Authorization": "token %s" % api_token}
-    resp = await fetch(HTTPRequest(url=url + "/info", headers=auth_header))
+    resp = await fetch(HTTPRequest(url=url + "/", headers=auth_header))
 
-    info = json.loads(resp.body.decode("utf8", "replace"))
-    state_filter = V(info["version"]) >= STATE_FILTER_MIN_VERSION
+    resp_model = json.loads(resp.body.decode("utf8", "replace"))
+    state_filter = V(resp_model["version"]) >= STATE_FILTER_MIN_VERSION
 
     now = datetime.now(timezone.utc)
 


### PR DESCRIPTION
By using /hub/api that returns a json-blob with a single version field
that we need, we don't require the `read:hub` scope for access to the
/hub/api/info endpoint that provides the hub version and more.
