### PR TITLE
Add dependabot to bump github actions and misc ci updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,16 @@
+# dependabot.yaml reference: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Notes:
+# - Status and logs from dependabot are provided at
+#   https://github.com/jupyterhub/jupyterhub-idle-culler/network/updates.
+#
+version: 2
+updates:
+  # Maintain dependencies in our GitHub Workflows
+  - package-ecosystem: github-actions
+    directory: /
+    labels: [ci]
+    schedule:
+      interval: monthly
+      time: "05:00"
+      timezone: Etc/UTC

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,8 @@ jobs:
             sqlalchemy-version: 1.*
           - python-version: "3.11"
             jupyterhub-version: 3.*
+          - python-version: "3.12"
+            jupyterhub-version: 4.*
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,11 +46,11 @@ jobs:
             jupyterhub-version: 4.*
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: "${{ matrix.python-version }}"
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "18"
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -52,7 +52,7 @@ jobs:
           python-version: "${{ matrix.python-version }}"
       - uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "lts/*"
 
       - name: Install configurable-http-proxy
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -77,6 +77,6 @@ jobs:
 
       - name: Run tests
         run: |
-          pytest --maxfail=2 --cov=jupyterhub_idle_culler
+          pytest --maxfail=2
 
       - uses: codecov/codecov-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ profile = "black"
 # ref: https://docs.pytest.org/en/stable/
 #
 [tool.pytest.ini_options]
-addopts = "--verbose --color=yes --durations=10"
+addopts = "--verbose --color=yes --durations=10 --cov=jupyterhub_idle_culler"
 asyncio_mode = "auto"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,20 +69,6 @@ remove-duplicate-keys = true
 remove-unused-variables = true
 
 
-# black is used for autoformatting Python code
-#
-# ref: https://black.readthedocs.io/en/stable/
-#
-[tool.black]
-target_version = [
-    "py37",
-    "py38",
-    "py39",
-    "py310",
-    "py311",
-]
-
-
 # isort is used for autoformatting Python code
 #
 # ref: https://pycqa.github.io/isort/


### PR DESCRIPTION
I ran into test failures in tljh due to distuitils was used in the last release. This is fixed, but we need a new release to be cut.