### PR TITLE
Replace tornado options with traitlets

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ python3 -m jupyterhub_idle_culler [--timeout=900] [--url=http://localhost:8081/h
                                    same time can slow down the Hub, so limit
                                    the number of API requests we have
                                    outstanding at any given time. (default 10)
+  --config                         Service configuration file to load.
+                                   (default idle_culler_config.py)
   --cull-admin-users               Whether admin users should be culled (only
                                    if --cull-users=true). (default True)
   --cull-every                     The interval (in seconds) for checking for

--- a/jupyterhub_idle_culler/__init__.py
+++ b/jupyterhub_idle_culler/__init__.py
@@ -656,7 +656,7 @@ class IdleCuller(Application):
     aliases = {
         "api-page-size": "IdleCuller.api_page_size",
         "concurrency": "IdleCuller.concurrency",
-        "config-file": "IdleCuller.config_file",
+        "config": "IdleCuller.config_file",
         "cull-admin-users": "IdleCuller.cull_admin_users",
         "cull-default-servers": "IdleCuller.cull_default_servers",
         "cull-every": "IdleCuller.cull_every",

--- a/jupyterhub_idle_culler/__init__.py
+++ b/jupyterhub_idle_culler/__init__.py
@@ -655,6 +655,7 @@ class IdleCuller(Application):
     aliases = {
         "api-page-size": "IdleCuller.api_page_size",
         "concurrency": "IdleCuller.concurrency",
+        "config-file": "IdleCuller.config_file",
         "cull-admin-users": "IdleCuller.cull_admin_users",
         "cull-default-servers": "IdleCuller.cull_default_servers",
         "cull-every": "IdleCuller.cull_every",

--- a/jupyterhub_idle_culler/__init__.py
+++ b/jupyterhub_idle_culler/__init__.py
@@ -704,6 +704,7 @@ class IdleCuller(Application):
         except KeyboardInterrupt:
             pass
 
+
 def main():
     IdleCuller.launch_instance()
 

--- a/jupyterhub_idle_culler/__init__.py
+++ b/jupyterhub_idle_culler/__init__.py
@@ -643,6 +643,7 @@ class IdleCuller(Application):
 
     url = Unicode(
         os.environ.get("JUPYTERHUB_API_URL"),
+        allow_none=True,
         help=dedent(
             """
             The JupyterHub API URL.

--- a/jupyterhub_idle_culler/__init__.py
+++ b/jupyterhub_idle_culler/__init__.py
@@ -581,16 +581,16 @@ class IdleCuller(Application):
 
     _log_formatter_cls = LogFormatter
 
-    @default('log_level')
+    @default("log_level")
     def _log_level_default(self):
         return logging.INFO
 
-    @default('log_datefmt')
+    @default("log_datefmt")
     def _log_datefmt_default(self):
         """Exclude date from default date format"""
         return "%Y-%m-%d %H:%M:%S"
 
-    @default('log_format')
+    @default("log_format")
     def _log_format_default(self):
         """override default log format to include time"""
         return "%(color)s[%(levelname)1.1s %(asctime)s.%(msecs).03d %(name)s %(module)s:%(lineno)d]%(end_color)s %(message)s"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "tornado",
     "packaging",
     "python-dateutil",
+    "traitlets",
 ]
 dynamic = ["version"]
 

--- a/tests/test_idle_culler.py
+++ b/tests/test_idle_culler.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 from subprocess import check_output
 from unittest import mock
 
+from tornado.log import app_log
 from jupyterhub_idle_culler import utcnow
 
 
@@ -32,7 +33,7 @@ async def test_cull_idle(cull_idle, start_users, admin_request):
     assert await count_active_users(admin_request) == 0
     await start_users(3)
     assert await count_active_users(admin_request) == 3
-    await cull_idle(inactive_limit=300)
+    await cull_idle(inactive_limit=300, logger=app_log)
     # no change
     assert await count_active_users(admin_request) == 3
 
@@ -40,7 +41,7 @@ async def test_cull_idle(cull_idle, start_users, admin_request):
     with mock.patch(
         "jupyterhub_idle_culler.utcnow", lambda: utcnow() + timedelta(seconds=600)
     ):
-        await cull_idle(inactive_limit=300)
+        await cull_idle(inactive_limit=300, logger=app_log)
     assert await count_active_users(admin_request) == 0
 
 

--- a/tests/test_idle_culler.py
+++ b/tests/test_idle_culler.py
@@ -4,6 +4,7 @@ from subprocess import check_output
 from unittest import mock
 
 from tornado.log import app_log
+
 from jupyterhub_idle_culler import utcnow
 
 


### PR DESCRIPTION
Here is a pass at what replacing tornado options with traitlets might look like.  Also,
* Adds an option to specify a loadable configuration file.
* Adds an flag that causes the application to print a default config file and exit.
* Preserves command line arguments with a set of aliases.
* Uses a traitlets `default` decorator to set the default `cull_every` to `timeout // 2`.

Using traitlets would provide a familiar way for JupyterHub admins to introduce additional logic in `handle_server()`, through a hook that could be defined via service configuration file.  Related to issue #44 and issues referenced therein.

Note this PR doesn't try to introduce a hook for that kind of configurable logic, it just changes tornado options to traitlets.  Can we discuss:
* Is this more or less the kind of thing we'd need to do?
* Does this break backwards compatibility...?  At first glance it doesn't seem to.
* Does the additional logging stuff traitlets brings in present a problem?