### PR TITLE
Configurable cull arbitration

### DIFF
--- a/jupyterhub_idle_culler/__init__.py
+++ b/jupyterhub_idle_culler/__init__.py
@@ -15,6 +15,7 @@ from textwrap import dedent
 from urllib.parse import quote
 
 import dateutil.parser
+from jupyterhub.utils import maybe_future
 from packaging.version import Version as V
 from tornado.httpclient import AsyncHTTPClient, HTTPRequest
 from tornado.httputil import url_concat
@@ -235,9 +236,13 @@ async def cull_idle(
         is_default_server = server_name == ""
         is_named_server = server_name != ""
 
+        cull_result = await maybe_future(
+            cull_arbiter(inactive=inactive, inactive_limit=inactive_limit, server=server)
+        )
+
         should_cull = (
             inactive is not None
-            and cull_arbiter(inactive=inactive, inactive_limit=inactive_limit, server=server)
+            and cull_result
             and (
                 (cull_default_servers and is_default_server)
                 or (cull_named_servers and is_named_server)
@@ -528,6 +533,10 @@ class IdleCuller(Application):
                         return False
                     return inactive.total_seconds() >= inactive_limit
                 c.IdleCuller.cull_arbiter_hook = my_cull_arbiter
+
+            - 'inactive' is the server's time since last activity, a timedelta object
+            - 'inactive_limit' is the idle timeout limit, in seconds
+            - 'server' is the server being considered for culling
 
             This callable should return True if the server should be culled, and
             False if it should not.  In this example, servers with a profile

--- a/jupyterhub_idle_culler/__init__.py
+++ b/jupyterhub_idle_culler/__init__.py
@@ -237,7 +237,9 @@ async def cull_idle(
         is_named_server = server_name != ""
 
         cull_result = await maybe_future(
-            cull_arbiter(inactive=inactive, inactive_limit=inactive_limit, server=server)
+            cull_arbiter(
+                inactive=inactive, inactive_limit=inactive_limit, server=server
+            )
         )
 
         should_cull = (
@@ -518,8 +520,7 @@ class IdleCuller(Application):
     cull_arbiter_hook = Callable(
         None,
         allow_none=True,
-        help=dedent(
-            """
+        help=dedent("""
             Enable custom culling logic.
 
             By default, the idle culler compares a server's time since last
@@ -542,8 +543,7 @@ class IdleCuller(Application):
             False if it should not.  In this example, servers with a profile
             name of "unlimited" are never culled, but all others are subject to
             the default time limit logic.
-            """
-        ).strip(),
+            """).strip(),
     ).tag(
         config=True,
     )

--- a/jupyterhub_idle_culler/__init__.py
+++ b/jupyterhub_idle_culler/__init__.py
@@ -78,7 +78,7 @@ def utcnow():
     return datetime.now(timezone.utc)
 
 
-def default_cull_arbiter(inactive, inactive_limit, server):
+def default_cull_arbiter(*, inactive, inactive_limit, server, **kwargs):
     """Return True if time inactive exceeds limit, the classic cull check."""
     return inactive.total_seconds() >= inactive_limit
 

--- a/jupyterhub_idle_culler/__init__.py
+++ b/jupyterhub_idle_culler/__init__.py
@@ -237,7 +237,7 @@ async def cull_idle(
 
         should_cull = (
             inactive is not None
-            and cull_arbiter(inactive, inactive_limit, server)
+            and cull_arbiter(inactive=inactive, inactive_limit=inactive_limit, server=server)
             and (
                 (cull_default_servers and is_default_server)
                 or (cull_named_servers and is_named_server)

--- a/jupyterhub_idle_culler/__init__.py
+++ b/jupyterhub_idle_culler/__init__.py
@@ -237,7 +237,9 @@ async def cull_idle(
 
         should_cull = (
             inactive is not None
-            and cull_arbiter(inactive=inactive, inactive_limit=inactive_limit, server=server)
+            and cull_arbiter(
+                inactive=inactive, inactive_limit=inactive_limit, server=server
+            )
             and (
                 (cull_default_servers and is_default_server)
                 or (cull_named_servers and is_named_server)

--- a/tests/test_idle_culler.py
+++ b/tests/test_idle_culler.py
@@ -34,6 +34,10 @@ def cull_arbiter_function(inactive, inactive_limit, server):
     return True
 
 
+async def async_cull_arbiter_function(inactive, inactive_limit, server):
+    return True
+
+
 async def test_cull_idle(cull_idle, start_users, admin_request):
     assert await count_active_users(admin_request) == 0
     await start_users(3)
@@ -55,6 +59,16 @@ async def test_custom_cull_arbiter(cull_idle, start_users, admin_request):
     await start_users(3)
     assert await count_active_users(admin_request) == 3
     await cull_idle(inactive_limit=300, logger=app_log, cull_arbiter=cull_arbiter_function)
+    # time has not passed but the cull arbiter function returns true
+    # so, everyone culled
+    assert await count_active_users(admin_request) == 0
+
+
+async def test_async_custom_cull_arbiter(cull_idle, start_users, admin_request):
+    assert await count_active_users(admin_request) == 0
+    await start_users(3)
+    assert await count_active_users(admin_request) == 3
+    await cull_idle(inactive_limit=300, logger=app_log, cull_arbiter=async_cull_arbiter_function)
     assert await count_active_users(admin_request) == 0
 
 

--- a/tests/test_idle_culler.py
+++ b/tests/test_idle_culler.py
@@ -54,7 +54,9 @@ async def test_custom_cull_arbiter(cull_idle, start_users, admin_request):
     assert await count_active_users(admin_request) == 0
     await start_users(3)
     assert await count_active_users(admin_request) == 3
-    await cull_idle(inactive_limit=300, logger=app_log, cull_arbiter=cull_arbiter_function)
+    await cull_idle(
+        inactive_limit=300, logger=app_log, cull_arbiter=cull_arbiter_function
+    )
     assert await count_active_users(admin_request) == 0
 
 

--- a/tests/test_idle_culler.py
+++ b/tests/test_idle_culler.py
@@ -30,6 +30,10 @@ async def count_active_users(admin_request):
     return active_users
 
 
+def cull_arbiter_function(inactive, inactive_limit, server):
+    return True
+
+
 async def test_cull_idle(cull_idle, start_users, admin_request):
     assert await count_active_users(admin_request) == 0
     await start_users(3)
@@ -43,6 +47,14 @@ async def test_cull_idle(cull_idle, start_users, admin_request):
         "jupyterhub_idle_culler.utcnow", lambda: utcnow() + timedelta(seconds=600)
     ):
         await cull_idle(inactive_limit=300, logger=app_log)
+    assert await count_active_users(admin_request) == 0
+
+
+async def test_custom_cull_arbiter(cull_idle, start_users, admin_request):
+    assert await count_active_users(admin_request) == 0
+    await start_users(3)
+    assert await count_active_users(admin_request) == 3
+    await cull_idle(inactive_limit=300, logger=app_log, cull_arbiter=cull_arbiter_function)
     assert await count_active_users(admin_request) == 0
 
 

--- a/tests/test_idle_culler.py
+++ b/tests/test_idle_culler.py
@@ -58,7 +58,9 @@ async def test_custom_cull_arbiter(cull_idle, start_users, admin_request):
     assert await count_active_users(admin_request) == 0
     await start_users(3)
     assert await count_active_users(admin_request) == 3
-    await cull_idle(inactive_limit=300, logger=app_log, cull_arbiter=cull_arbiter_function)
+    await cull_idle(
+        inactive_limit=300, logger=app_log, cull_arbiter=cull_arbiter_function
+    )
     # time has not passed but the cull arbiter function returns true
     # so, everyone culled
     assert await count_active_users(admin_request) == 0
@@ -68,7 +70,9 @@ async def test_async_custom_cull_arbiter(cull_idle, start_users, admin_request):
     assert await count_active_users(admin_request) == 0
     await start_users(3)
     assert await count_active_users(admin_request) == 3
-    await cull_idle(inactive_limit=300, logger=app_log, cull_arbiter=async_cull_arbiter_function)
+    await cull_idle(
+        inactive_limit=300, logger=app_log, cull_arbiter=async_cull_arbiter_function
+    )
     assert await count_active_users(admin_request) == 0
 
 


### PR DESCRIPTION
Here's a proposal at making configurable the decision about whether or not to cull a server.  The idea is to provide a hook that can be configured that takes 3 arguments.  The first 2 are the usual inputs to decide whether or not to cull --- the idle time of a server and the idle time limit.  The third argument is the server dict.  Default cull arbitration is the familiar:

```
def default_cull_arbiter(inactive, inactive_limit, server):
    """Return True if time inactive exceeds limit, the classic cull check."""
    return inactive.total_seconds() >= inactive_limit
```

But now the user can do this in a `traitlets` config file since #83 is merged:

```
def my_cull_arbiter(inactive, inactive_limit, server):
    if server['state']['profile_name'] == 'unlimited':
        return False
    return inactive.total_seconds() >= inactive_limit
c.IdleCuller.cull_arbiter_hook = my_cull_arbiter
```

This exempts servers with a profile name of "unlimited" from ever being culled.  For this to work the cull arbitration function needs to "know" about the kinds of stuff it can check in the server dict.  Some other changes and things to note:

- Imports the `Callable` traitlet; if the `cull_arbiter_hook` is left as None then the default behavior is used
- If the user wants to be able to re-use the idle timeout comparison, there might be better ways than saying "always remember to include this `return inactive.total_seconds()...` line.  But the user still has to know they need to either include that check or somehow tell the culler to do it in addition to (or instead of) whatever logic they've got.
- Removes some comments advising on how to customize logic via patching the code
- Should be documented, however this ends up getting done

Questions:

- Do people like this or not?
- What kind of tests does this need?
- The comments about how to customize through patching the code opened the door to even more arbitrary changes but I decided not to enable those suggestions there --- this just checks the server state.

Addresses #9, #25
